### PR TITLE
prevents static properties (i.e. non functions) from causing #implements...

### DIFF
--- a/lib/topiarist.js
+++ b/lib/topiarist.js
@@ -652,14 +652,16 @@
 	 */
 	function missingAttributes(classdef, protocol) {
 		var result = [], obj = classdef.prototype, requirement = protocol.prototype;
-		for (var item in requirement) {
+		var item;
+		for (item in requirement) {
 			if (typeof obj[item] !== typeof requirement[item]) {
 				result.push(item);
 			}
 		}
 
-		for (var item in protocol) {
-			if (protocol.hasOwnProperty(item) &&  typeof classdef[item] !== typeof protocol[item]) {
+		for (item in protocol) {
+			var protocolItemType = typeof protocol[item];
+			if (protocol.hasOwnProperty(item) && protocolItemType === 'function' && typeof classdef[item] !== protocolItemType) {
 				// If we're in ie8, our internal variables won't be nonenumerable, so we include a check for that here.
 				if (internalUseNames.indexOf(item) < 0) {
 					result.push(item + ' (class method)');

--- a/spec/hasImplementedSpec.js
+++ b/spec/hasImplementedSpec.js
@@ -58,6 +58,18 @@ describe("topiarist.hasImplemented", function() {
 		expect(true).toBe(true);
 	});
 
+	it("does not throw an error if the class doesn't define static 'class' properties specified by the interface.", function() {
+		Class.prototype.interfaceMethod = function() {};
+		Class.prototype.anotherInterfaceMethod = function() {};
+
+		[1, NaN, 'a', null, true].forEach(function(prop, idx) {
+			Interface['staticProperty_'+idx] = prop;
+		});
+
+		topiarist.hasImplemented(Class, Interface);
+		expect(true).toBe(true);
+	});
+
 	it("does not throw an error if the class inherits (using topiarist.extend) methods required by the interface.", function() {
 		Class.prototype.interfaceMethod = function() {};
 		Class.prototype.anotherInterfaceMethod = function() {};


### PR DESCRIPTION
... to fail
